### PR TITLE
Feat: 폴더 삭제 및 폴더명 로직 추가

### DIFF
--- a/public/delete.svg
+++ b/public/delete.svg
@@ -1,0 +1,8 @@
+<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.6 5.1H14.4V15.5C14.4 16.2732 13.7732 16.9 13 16.9H5C4.2268 16.9 3.6 16.2732 3.6 15.5V5.1Z" stroke="#9FA6B2" stroke-width="1.2"/>
+<path d="M6.48387 3.0741C6.72102 2.5998 7.20579 2.3002 7.73607 2.3002H10.2639C10.7942 2.3002 11.279 2.5998 11.5161 3.0741L12.5292 5.1002H5.47082L6.48387 3.0741Z" stroke="#9FA6B2" stroke-width="1.2"/>
+<rect x="1.5" y="4.5" width="15" height="1.2" rx="0.6" fill="#9FA6B2"/>
+<rect x="9.59998" y="7.5" width="7" height="1.2" rx="0.6" transform="rotate(90 9.59998 7.5)" fill="#9FA6B2"/>
+<rect x="12.2" y="7.5" width="7" height="1.2" rx="0.6" transform="rotate(90 12.2 7.5)" fill="#9FA6B2"/>
+<rect x="7.19995" y="7.5" width="7" height="1.2" rx="0.6" transform="rotate(90 7.19995 7.5)" fill="#9FA6B2"/>
+</svg>

--- a/src/api/folder.ts
+++ b/src/api/folder.ts
@@ -21,3 +21,25 @@ export const postFolder = async (newFolderName) => {
     throw error;
   }
 };
+
+export const deleteFolder = async (folderId) => {
+  try {
+    const response = await apiClient.delete(`/folders/${folderId}`);
+    return response.data;
+  } catch (error) {
+    console.error("deleteFolder 에러", error.response?.data || error.message);
+    throw error;
+  }
+};
+
+export const changeFolderName = async (folderId, newFolderName) => {
+  try {
+    const response = await apiClient.put(`/folders/${folderId}`, {
+      name: newFolderName,
+    });
+    return response.data;
+  } catch (error) {
+    console.error("changeFolderName 에러", error.response?.data || error.message);
+    throw error;
+  }
+};

--- a/src/components/Folder/DeleteFolderImage.tsx
+++ b/src/components/Folder/DeleteFolderImage.tsx
@@ -1,0 +1,16 @@
+import DeleteFolderModal from "../Modal/DeleteFolderModal";
+import { useState } from "react";
+
+export default function DeleteFolderImage({ currentFolder }) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const handleModalOpen = () => setIsModalOpen(!isModalOpen);
+  return (
+    <>
+      <button className="flex items-center gap-1 text-gray02 md:text-2xl" onClick={() => handleModalOpen()}>
+        <img src="/delete.svg" alt="" />
+        Delete
+      </button>
+      {isModalOpen && <DeleteFolderModal currentFolder={currentFolder} setIsModalOpen={setIsModalOpen} />}
+    </>
+  );
+}

--- a/src/components/Modal/DeleteFolderModal.tsx
+++ b/src/components/Modal/DeleteFolderModal.tsx
@@ -1,0 +1,30 @@
+import Button from "../Button";
+import { IoCloseCircleOutline } from "react-icons/io5";
+import { deleteFolder } from "../../api/folder";
+
+export default function DeleteFolderModal({ currentFolder, setIsModalOpen }) {
+  const handleDeleteFolder = async () => {
+    try {
+      await deleteFolder(currentFolder.id);
+      setIsModalOpen(false);
+    } catch (error) {
+      console.error("폴더 삭제 중 오류", error);
+    }
+  };
+  const handleModalClose = (current) => setIsModalOpen(!current);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="relative z-[10000] flex h-auto w-[400px] flex-col items-center rounded-3xl bg-white p-10 shadow-lg">
+        <IoCloseCircleOutline className="absolute right-3 top-3 cursor-pointer text-3xl" onClick={handleModalClose} />
+
+        <h2 className="mb-2 text-4xl">폴더 삭제</h2>
+        <span>{currentFolder.name}</span>
+
+        <div className="mt-6">
+          <Button size="md" text="삭제하기" onClick={handleDeleteFolder} />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔎 작업 내용
1. 폴더 관련 api 추가
   - 폴더명 변경 api 추가: `changeFolderName`
   - 폴더 삭제 api 추가: `deleteFolder`
2. 폴더 삭제 로직 추가
   - 삭제이미지 추가: `DeleteFolderImage`
   - 삭제 모달 추가: `DeleteFolderModal`

## 🎯 로직   
1. 삭제이미지 클릭
<img src="https://github.com/user-attachments/assets/201dedfc-982e-4809-9dc9-1c2e2334b6bb" width="200"/>

2. 삭제모달 열림
3. 삭제하기 클릭 시 폴더 삭제 요청 전송
4. 모달창 닫힘

<img src="https://github.com/user-attachments/assets/c603e5dd-a1ba-415a-a837-a393bf30180f" width="400"/>


🧩 앞으로의 과제
폴더 삭제 후 새로고침 또는 invalidate Query를 통해 렌더링 최신화