### PR TITLE
Feat: 로그인 및 회원가입 구현 

### DIFF
--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,3 +1,6 @@
+import { MdEmail } from "react-icons/md";
+import apiClient from "./axiosInstance";
+
 export const postLogin = async (email, password) => {
   try {
     const response = await fetch("https://linkbrary-api.vercel.app/40-1/auth/sign-in", {
@@ -27,5 +30,19 @@ export const postLogin = async (email, password) => {
 
     // 에러 메시지를 반환하거나, 필요 시 사용자에게 전달할 수 있는 형식으로 처리
     return { error: error.message };
+  }
+};
+
+export const postSignUp = async (email, password, name) => {
+  try {
+    const response = await apiClient.post("/auth/sign-up", {
+      email: email,
+      password: password,
+      name: name,
+    });
+    return response.data;
+  } catch (error) {
+    console.error("putFavoite", error.response?.data || error.message);
+    throw error;
   }
 };

--- a/src/components/CommonInput.tsx
+++ b/src/components/CommonInput.tsx
@@ -5,14 +5,15 @@ interface ICommonInput {
   placeholder: string;
 }
 
-export default function CommonInput({ labelName, register, name, placeholder }: ICommonInput) {
+export default function CommonInput({ labelName, register, name, placeholder, type = "text" }: ICommonInput) {
   return (
-    <div>
-      <label className="mb-2 text-xl">{labelName}</label>
+    <div className="mb-4 flex flex-col">
+      <label className="mb-1 font-semibold">{labelName}</label>
       <input
-        placeholder={placeholder}
         {...register(name)}
-        className="my-2 h-[50px] w-full rounded-lg border border-gray03 bg-white px-3 text-xl focus:border-primary focus:outline-none"
+        type={type} // ✅ 여기서 type을 적용해야 함!
+        placeholder={placeholder}
+        className="rounded-md border p-2 outline-none focus:border-primary"
       />
     </div>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,13 +6,17 @@ export default function Header() {
   const navigate = useNavigate();
   const moveToLinks = () => navigate("/links");
   const moveToFavorite = () => navigate("/favorite");
+  const handleLogout = () => {
+    document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;"; // 쿠키 만료
+    navigate("/login"); // 로그인 페이지 이동
+  };
   return (
     <div className="my-4 flex h-[65px] w-full max-w-[1200px] items-center justify-between bg-gray05 md:my-6">
       <img src="/savelinks.svg" onClick={moveToLinks} className="cursor-pointer" />
       <div className="flex gap-4">
         <UserFavoriteLinks onClick={moveToFavorite} />
         <div className="rounded-full bg-logo p-1">
-          <FaUserCircle className="text-3xl text-white" />
+          <FaUserCircle className="cursor-pointer text-3xl text-white" onClick={handleLogout} />
         </div>
       </div>
     </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -34,7 +34,9 @@ export default function Login() {
     <div className="flex h-screen flex-col items-center justify-center">
       <div className="flex flex-col items-center justify-center">
         <img src="/savelinks.svg" width={180} alt="Logo" />
-        <a className="text-primary">회원 가입하기</a>
+        <button className="text-primary" onClick={() => navigate("/signup")}>
+          Signup
+        </button>
       </div>
       <form className="flex w-full max-w-[400px] flex-col" onSubmit={handleSubmit(handleLogin)}>
         {/* 이메일 입력 */}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,7 +15,10 @@ export default function Login() {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm({ resolver: zodResolver(schema) });
+  } = useForm({
+    resolver: zodResolver(schema),
+    mode: "onChange",
+  });
 
   const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false); // 비밀번호 보이기/숨기기 상태

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,3 +1,5 @@
+import { AiFillEye, AiFillEyeInvisible } from "react-icons/ai"; // react-icons 아이콘 추가
+
 import Button from "../components/Button";
 import CommonInput from "../components/CommonInput";
 import { getFolder } from "../api/folder";
@@ -5,6 +7,7 @@ import { postLogin } from "../api/login";
 import schema from "../zod/LoginZod";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 export default function Login() {
@@ -15,34 +18,47 @@ export default function Login() {
   } = useForm({ resolver: zodResolver(schema) });
 
   const navigate = useNavigate();
-  const onsubmit = (data) => {
+  const [showPassword, setShowPassword] = useState(false); // 비밀번호 보이기/숨기기 상태
+
+  const handleLogin = (data) => {
     const { email, password } = data;
     postLogin(email, password)
-      .then((response) => {
-        navigate("/links");
-      })
+      .then(() => navigate("/links"))
       .catch((error) => console.error(error));
-  };
-
-  const check1 = () => {
-    getFolder();
   };
 
   return (
     <div className="flex h-screen flex-col items-center justify-center">
-      <div>
-        <img src="/savelinks.svg" width={180} />
-        <p>회원이 아니신가요?</p>
-        <a>회원가입하기</a>
+      <div className="flex flex-col items-center justify-center">
+        <img src="/savelinks.svg" width={180} alt="Logo" />
+        <a className="text-primary">회원 가입하기</a>
       </div>
-      <form className="flex w-full max-w-[400px] flex-col" onSubmit={handleSubmit(onsubmit)}>
+      <form className="flex w-full max-w-[400px] flex-col" onSubmit={handleSubmit(handleLogin)}>
+        {/* 이메일 입력 */}
         <CommonInput register={register} name="email" placeholder="이메일을 입력해주세요" labelName="이메일" />
         {errors.email && <p className="mb-3 text-red-500">{errors.email.message}</p>}
-        <CommonInput register={register} name="password" placeholder="비밀번호를 입력해주세요" labelName="비밀번호" />
+
+        {/* 비밀번호 입력 */}
+        <div className="relative">
+          <CommonInput
+            register={register}
+            name="password"
+            placeholder="비밀번호를 입력해주세요"
+            labelName="비밀번호"
+            type={showPassword ? "text" : "password"}
+          />
+          <button
+            type="button"
+            className="absolute right-3 top-[50%] translate-y-[-20%] text-gray-500"
+            onClick={() => setShowPassword(!showPassword)}
+          >
+            {showPassword ? <AiFillEyeInvisible size={20} /> : <AiFillEye size={20} />}
+          </button>
+        </div>
         {errors.password && <p className="mb-3 text-red-500">{errors.password.message}</p>}
+
         <Button size="response" text="로그인" />
       </form>
-      <button onClick={check1}>asdasd</button>
     </div>
   );
 }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,86 @@
-import React from "react";
+import { AiFillEye, AiFillEyeInvisible } from "react-icons/ai";
+
+import Button from "../components/Button";
+import CommonInput from "../components/CommonInput";
+import { postSignUp } from "../api/login";
+import schema from "../zod/SingUpZod";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 export default function SignUp() {
-  return <div>회원가입</div>;
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({ resolver: zodResolver(schema) });
+
+  const navigate = useNavigate();
+
+  const handleSignUp = (data) => {
+    const { email, password, name } = data;
+    postSignUp(email, password, name)
+      .then(() => navigate("/login"))
+      .catch((error) => console.error(error));
+  };
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center">
+      <div className="flex flex-col items-center justify-center">
+        <img src="/savelinks.svg" width={180} alt="Logo" />
+        <button className="text-primary" onClick={() => navigate("/login")}>
+          Login
+        </button>
+      </div>
+      <form className="flex w-full max-w-[400px] flex-col" onSubmit={handleSubmit(handleSignUp)}>
+        <CommonInput register={register} name="email" placeholder="이메일을 입력해주세요" labelName="이메일" />
+        {errors.email && <p className="mb-3 text-red-500">{errors.email.message}</p>}
+
+        <CommonInput register={register} name="name" placeholder="이름을 입력해주세요" labelName="이름" />
+        {errors.name && <p className="mb-3 text-red-500">{errors.name.message}</p>}
+
+        <div className="relative">
+          <CommonInput
+            register={register}
+            name="password"
+            placeholder="비밀번호를 입력해주세요"
+            labelName="비밀번호"
+            type={showPassword ? "text" : "password"}
+          />
+          <button
+            type="button"
+            className="absolute right-3 top-[50%] translate-y-[-20%] text-gray-500"
+            onClick={() => setShowPassword(!showPassword)}
+          >
+            {showPassword ? <AiFillEyeInvisible size={20} /> : <AiFillEye size={20} />}
+          </button>
+        </div>
+        {errors.password && <p className="mb-3 text-red-500">{errors.password.message}</p>}
+
+        <div className="relative">
+          <CommonInput
+            register={register}
+            name="confirmPassword"
+            placeholder="비밀번호를 다시 입력해주세요"
+            labelName="비밀번호 확인"
+            type={showConfirmPassword ? "text" : "password"}
+          />
+          <button
+            type="button"
+            className="absolute right-3 top-[50%] translate-y-[-20%] text-gray-500"
+            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+          >
+            {showConfirmPassword ? <AiFillEyeInvisible size={20} /> : <AiFillEye size={20} />}
+          </button>
+        </div>
+        {errors.confirmPassword && <p className="mb-3 text-red-500">{errors.confirmPassword.message}</p>}
+
+        <Button size="response" text="회원가입" />
+      </form>
+    </div>
+  );
 }

--- a/src/zod/SingUpZod.ts
+++ b/src/zod/SingUpZod.ts
@@ -8,7 +8,11 @@ const schema = z.object({
   password: z
     .string()
     .min(8, { message: "비밀번호는 최소 8자 이상이어야 합니다." })
-    .max(100, { message: "비밀번호는 100자를 초과할 수 없습니다." }),
+    .max(20, { message: "비밀번호는 20자를 초과할 수 없습니다." }),
+  name: z
+    .string()
+    .min(1, { message: "이름은 필수 입력 항목입니다." })
+    .max(20, { message: "이름은 20자를 초과할 수 없습니다." }),
 });
 
 export default schema;


### PR DESCRIPTION
## 🔎 작업 내용
1. 로그인페이지 유효성 검사 추가
   - `LoginZod` 를 통해 이메일 검사 및 필수입력 / 비밀번호 최소8자 규칙 설정
   - `Sighup` 클릭 시 회원가입 페이지 이동 로직 추가 
   - 비밀번호 보이기 옵션을 눈모양 아이콘으로 설정하게 추가 
      <img src="https://github.com/user-attachments/assets/647a699a-f498-4577-a801-b99ca7af1686" width=300/>


2. 회원가입 페이지 추가 
   - `SignupZod`  를 통해 이메일 검사 및 비밀번호 검사 규칙 설정
   - 비밀번호 확인 로직 추가 

3. 로그아웃 구현
   - `FaUserCircle` 클릭 시 로그아웃 
   
## 🎯 로직   
1. 비회원 시 회원가입 페이지 이동 
2. 이메일 / 이름 / 비밀번호를 입력하고 회원가입
3. 이메일 / 비밀번호를 통해 로그인 
5. 메인페이지 유저아이콘을 통해 로그아웃 