### PR TITLE
Feat: 폴더 / 링크 요청에 invalidateQueries 적용

### DIFF
--- a/src/components/Modal/AddFolderModal.tsx
+++ b/src/components/Modal/AddFolderModal.tsx
@@ -2,13 +2,17 @@ import { AddFolderModalProps } from "../../type/folder";
 import Button from "../Button";
 import { IoCloseCircleOutline } from "react-icons/io5";
 import { postFolder } from "../../api/folder";
+import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 export default function AddFolderModal({ setIsAddFolderOpen }: AddFolderModalProps) {
   const [newFolderName, setNewFolderName] = useState("");
 
-  const fetchPostFolder = () => {
-    postFolder(newFolderName);
+  const queryClient = useQueryClient();
+
+  const handlePostNewFolder = async () => {
+    await postFolder(newFolderName); // 새로운 폴더 추가
+    await queryClient.invalidateQueries({ queryKey: ["folders"] }); // "folders" 쿼리 무효화
     setIsAddFolderOpen(false);
   };
 
@@ -30,7 +34,7 @@ export default function AddFolderModal({ setIsAddFolderOpen }: AddFolderModalPro
           }}
         />
         <div className="mt-auto">
-          <Button size="md" text="추가하기" onClick={fetchPostFolder} />
+          <Button size="md" text="추가하기" onClick={handlePostNewFolder} />
         </div>
       </div>
     </div>

--- a/src/components/Modal/DeleteFolderModal.tsx
+++ b/src/components/Modal/DeleteFolderModal.tsx
@@ -2,16 +2,22 @@ import Button from "../Button";
 import { EditFolderNameModalProps } from "../../type/folder";
 import { IoCloseCircleOutline } from "react-icons/io5";
 import { deleteFolder } from "../../api/folder";
+import { useQueryClient } from "@tanstack/react-query";
 
 export default function DeleteFolderModal({ currentFolder, setIsModalOpen }: EditFolderNameModalProps) {
+  const queryClient = useQueryClient();
+
   const handleDeleteFolder = async () => {
     try {
-      await deleteFolder(currentFolder.id);
-      setIsModalOpen(false);
+      await deleteFolder(currentFolder.id); // 폴더 삭제 요청
+      await queryClient.invalidateQueries({ queryKey: ["folders"] }); // "folders" 쿼리 무효화
+      setIsModalOpen(false); // 모달 닫기
+      window.location.reload(); // 삭제 후 페이지 새로고침
     } catch (error) {
       console.error("폴더 삭제 중 오류", error);
     }
   };
+
   const handleModalClose = () => setIsModalOpen(false);
 
   return (

--- a/src/components/Modal/LinkDeleteDropdownModal.tsx
+++ b/src/components/Modal/LinkDeleteDropdownModal.tsx
@@ -2,6 +2,7 @@ import Button from "../Button";
 import { DeleteLinkUrl } from "../../api/links";
 import { IoCloseCircleOutline } from "react-icons/io5";
 import { LinkDeleteDropdownModalProps } from "../../type/modal";
+import { useQueryClient } from "@tanstack/react-query";
 
 export default function LinkDeleteDropdownModal({ setIsDeleteModalOpen, linkId }: LinkDeleteDropdownModalProps) {
   const handleModalClose = (e: React.MouseEvent<SVGElement, MouseEvent>): void => {
@@ -9,10 +10,18 @@ export default function LinkDeleteDropdownModal({ setIsDeleteModalOpen, linkId }
     setIsDeleteModalOpen((prev) => !prev);
   };
 
+  const queryClient = useQueryClient();
+
   const sendDeleteRequest = async (): Promise<void> => {
-    await DeleteLinkUrl(linkId);
-    setIsDeleteModalOpen((prev) => !prev);
+    try {
+      await DeleteLinkUrl(linkId); // 링크 삭제 요청
+      await queryClient.invalidateQueries({ queryKey: ["links"] }); // "links" 쿼리 무효화
+      setIsDeleteModalOpen((prev) => !prev); // 모달 닫기
+    } catch (error) {
+      console.error("링크 삭제 중 오류", error);
+    }
   };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div className="relative z-[10000] flex h-auto w-[400px] flex-col items-center rounded-3xl bg-white p-10 shadow-lg">

--- a/src/components/Modal/LinkEditDropdownModal.tsx
+++ b/src/components/Modal/LinkEditDropdownModal.tsx
@@ -2,20 +2,24 @@ import Button from "../Button";
 import { EditLinkUrl } from "../../api/links";
 import { IoCloseCircleOutline } from "react-icons/io5";
 import { LinkEditDropdownModalProps } from "../../type/modal";
+import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 export default function LinkEditDropdownModal({ setIsEditModalOpen, linkId }: LinkEditDropdownModalProps) {
   const [newLink, setNewLink] = useState<string>("");
 
+  const queryClient = useQueryClient();
+
   const handleModalClose = (e: React.MouseEvent<SVGElement, MouseEvent>): void => {
     e.preventDefault();
-    setIsEditModalOpen((prev) => !prev);
+    setIsEditModalOpen(false);
   };
 
   const sendEditLinkRequest = async (): Promise<void> => {
     try {
       await EditLinkUrl(linkId, newLink);
-      setIsEditModalOpen((prev) => !prev);
+      await queryClient.invalidateQueries({ queryKey: ["links"] }); // "links" 쿼리 무효화
+      setIsEditModalOpen(false);
     } catch (error) {
       console.error("폴더명 수정 중 오류", error);
     }

--- a/src/components/Modal/SelectLinkFolderModal.tsx
+++ b/src/components/Modal/SelectLinkFolderModal.tsx
@@ -3,14 +3,18 @@ import { CiBookmarkCheck } from "react-icons/ci";
 import { IoCloseCircleOutline } from "react-icons/io5";
 import { SelectLinkFolderModalProps } from "../../type/modal";
 import { postLinks } from "../../api/links";
+import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 export default function SelectLinkFolderModal({ setIsModal, folderList, newLink }: SelectLinkFolderModalProps) {
   const [selectFolder, setSelectFolder] = useState<number | null>(null);
 
-  const handlePostNewLink = () => {
+  const queryClient = useQueryClient();
+
+  const handlePostNewLink = async () => {
     if (selectFolder !== null) {
-      postLinks(newLink, selectFolder);
+      await postLinks(newLink, selectFolder);
+      await queryClient.invalidateQueries({ queryKey: ["links"] }); // "links" 쿼리 무효화
       setIsModal(false);
     }
   };


### PR DESCRIPTION
## 🔎 작업 내용
- React Query를 활용하여 데이터 변경 후 자동으로 최신 데이터를 불러오도록 쿼리 무효화(invalidateQueries) 적용
- 폴더 및 링크 관련 API 요청 후 데이터 동기화 로직 개선
- 삭제 및 수정 후 화면 새로고침 기능 추가

## 🎯 주요 변경 사항
- invalidateQueries를 활용하여 폴더 및 링크 목록의 최신 상태 유지
- 폴더 추가, 삭제, 수정 후 자동으로 데이터 반영되도록 개선
- window.location.reload()를 활용하여 데이터 삭제 후 즉시 화면 갱신 기능 추가

## 🚀 기대 효과
- 폴더 및 링크 데이터 변경 시, 최신 상태를 유지하여 사용자 경험 개선
- 불필요한 네트워크 요청 최소화 및 React Query의 캐싱 전략 활용
- 삭제 및 수정 후 자동으로 새로고침하여 사용자에게 즉각적인 변화 제공
- 전체적인 유지보수성 증가 및 성능 최적화