### PR TITLE
Feat: 메모 로컬스토리지 저장 구현 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,9 +9,9 @@ import Home from "./pages/Home";
 import Layout from "./components/layout/Layout";
 import Links from "./pages/Links";
 import Login from "./pages/Login";
+import Memos from "./pages/Memos";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"; // Devtools 추가
 import SignUp from "./pages/SignUp";
-import Todos from "./pages/Todos";
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { persistQueryClient } from "@tanstack/react-query-persist-client";
 
@@ -44,9 +44,9 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<SignUp />} />
+          <Route path="/memos" element={<Memos />} />
           <Route element={<Layout />}>
             <Route path="/links" element={<Links />} />
-            <Route path="/todos" element={<Todos />} />
             <Route path="/favorite" element={<Favorite />} />
           </Route>
         </Routes>

--- a/src/pages/Memos.tsx
+++ b/src/pages/Memos.tsx
@@ -1,13 +1,29 @@
+import { useEffect, useState } from "react";
+
 import AddMemo from "../components/Memos/AddMemo";
 import Header from "../components/Header";
 import MemoItem from "../components/Memos/MemoItem";
 import { MemoProps } from "../type/memo";
 import NoMemos from "../components/Memos/NoMemos";
-import { useState } from "react";
 
 export default function Memos() {
-  const [memos, setMemos] = useState<MemoProps[]>([]); // 메모 배열
   const [selectedMemo, setSelectedMemo] = useState<MemoProps | null>(null); // 선택된 메모
+
+  // 메모 로컬스토리지에서 불러오기
+  const [memos, setMemos] = useState<MemoProps[]>(() => {
+    try {
+      const stored = localStorage.getItem("memos");
+      return stored ? JSON.parse(stored) : [];
+    } catch (e) {
+      console.error("로컬스토리지 파싱 에러:", e);
+      return [];
+    }
+  });
+
+  // memos 상태가 바뀔 때마다 로컬스토리지에 저장
+  useEffect(() => {
+    localStorage.setItem("memos", JSON.stringify(memos));
+  }, [memos]);
 
   return (
     <>


### PR DESCRIPTION
## 🔎 작업 내용
- 메모 로컬스토리지 연동
    - memos 상태를 localStorage와 연동하여 새로고침해도 메모가 유지되도록 처리
    - useEffect를 사용하여 메모 상태 변경 시 자동으로 localStorage에 저장
    - useState의 초기값으로 localStorage의 데이터를 로드하도록 개선
    - JSON 파싱 중 오류 발생 가능성을 고려하여 try-catch 처리 추가

- 빌드 오류 해결 
    - 페이지 경로 todo에서 memo로 수정

## 🎯 주요 변경 사항
- useState 초기값에 함수형 접근 방식 적용
  → localStorage에서 초기 데이터 불러오도록 설정

- useEffect를 통해 memos 상태가 변경될 때마다 자동 저장

- 기존 초기값 [] → localStorage에서 불러온 값으로 대체

## 🚀 기대 효과
- 새로고침해도 메모 데이터 유지 → 사용자 경험 향상
- 백엔드 없이도 데이터 저장 가능 → 빠른 프로토타이핑에 적합
- 구조 단순화 → Redux, React Query 없이도 간단한 상태 + 저장 로직 구현 가능

