### PR TITLE
Feat: 유튜브/인스타 링크 자동 embed 처리 및 iframe 적용

### DIFF
--- a/src/components/AddLink.tsx
+++ b/src/components/AddLink.tsx
@@ -18,7 +18,7 @@ export default function AddLink() {
 
   const [newLink, setNewLink] = useState("");
   const [isModal, setIsModal] = useState(false);
-  console.log(newLink);
+
   const handleModalOpen = () => {
     if (!isValidUrl(newLink)) {
       toast.warn("유효한 링크 형식을 입력해주세요", {

--- a/src/components/Modal/SelectLinkFolderModal.tsx
+++ b/src/components/Modal/SelectLinkFolderModal.tsx
@@ -1,3 +1,5 @@
+import { normalizeInstagramUrl, normalizeYoutubeUrl } from "../../utils/urlUtils";
+
 import Button from "../Button";
 import { CiBookmarkCheck } from "react-icons/ci";
 import { IoCloseCircleOutline } from "react-icons/io5";
@@ -13,8 +15,16 @@ export default function SelectLinkFolderModal({ setIsModal, folderList, newLink 
 
   const handlePostNewLink = async () => {
     if (selectFolder !== null) {
-      await postLinks(newLink, selectFolder);
-      await queryClient.invalidateQueries({ queryKey: ["links"] }); // "links" 쿼리 무효화
+      let cleanedLink = newLink.trim();
+
+      if (cleanedLink.includes("youtube.com") || cleanedLink.includes("youtu.be")) {
+        cleanedLink = normalizeYoutubeUrl(cleanedLink);
+      } else if (cleanedLink.includes("instagram.com")) {
+        cleanedLink = normalizeInstagramUrl(cleanedLink);
+      }
+
+      await postLinks(cleanedLink, selectFolder);
+      await queryClient.invalidateQueries({ queryKey: ["links"] });
       setIsModal(false);
     }
   };

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -9,3 +9,65 @@ export const isValidImage = (src?: string) =>
 // url 로직 통일
 export const normalizeUrl = (url: string) =>
   url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`;
+
+// 인스타 확인
+export const isInstagramReel = (url: string): boolean => {
+  return url.includes("instagram.com/reel");
+};
+
+// 인스타 ID 추출
+export const extractInstagramId = (url: string): string => {
+  const match = url.match(/\/reel\/([^\/?]+)/);
+  return match ? match[1] : "";
+};
+
+// 인스타 임베드용 변환
+export const normalizeInstagramUrl = (url: string): string => {
+  url = url.trim(); // 공백제거
+
+  // 공유 버전으로 변경
+  if (url.includes("instagram.com/reels/")) {
+    url = url.replace("instagram.com/reels/", "instagram.com/reel/");
+  }
+  // 정규식
+  const isReel = /instagram\.com\/reel\/[^\/?]+/.test(url);
+
+  // 공유버전 확인
+  const hasUtm = url.includes("utm_source");
+
+  if (isReel && !hasUtm) {
+    const normalized = url.endsWith("/") ? `${url}?utm_source=ig_web_copy_link` : `${url}/?utm_source=ig_web_copy_link`;
+    return normalized;
+  }
+
+  return url;
+};
+
+// 유튜브 확인
+export const isYoutube = (url: string): boolean => {
+  return url.includes("youtube.com");
+};
+
+// 유튜브 ID 추출
+export const extractYoutubeId = (url: string): string => {
+  const match = url.match(/\/shorts\/([^\/?]+)/);
+  return match ? match[1] : "";
+};
+
+// 유튜브 임베드용 변환
+export const normalizeYoutubeUrl = (url: string): string => {
+  url = url.trim();
+
+  // Shorts URL 처리
+  const shortsMatch = url.match(/youtube\.com\/shorts\/([^?&]+)/);
+  if (shortsMatch) {
+    return `https://www.youtube.com/embed/${shortsMatch[1]}`;
+  }
+  // 일반영상 URL 처리
+  const videoMatch = url.match(/v=([^?&]+)/);
+  if (videoMatch) {
+    return `https://www.youtube.com/embed/${videoMatch[1]}`;
+  }
+
+  return url;
+};


### PR DESCRIPTION
## 🔎 작업 내용
- 유튜브 및 인스타그램 URL을 iframe에서 바로 사용할 수 있도록 **embed URL로 자동 변환**하는 로직 구현
- 신규 링크 등록 시, 입력된 URL을 기반으로 **자동 embed 처리**
- URL 유형에 따라 **다른 iframe 레이아웃 적용**

## 🎯 주요 변경 사항
- `YouTube`, `Instagram` 링크를 감지하고 embed URL로 변환
- `iframe` src에 embed된 링크를 적용해 콘텐츠 미리보기 구현
- 프레임 스타일을 플랫폼별로 다르게 렌더링하는 로직 추가
- 코드 정리를 위한 콘솔 로그 삭제

 
## 🚀 기대 효과
- 미디어 콘텐츠 미리보기 제공
- YouTube/Instagram 콘텐츠를 즉시 확인 가능
- embed 처리 구조화로 **향후 TikTok 등 플랫폼 확장 가능성 확보**
- 크롬 익스텐션 기능을 추가로 구현하여 발전 가능
